### PR TITLE
MISTAKE: Improve UX of ifup script, in case of failures

### DIFF
--- a/scripts/ifup.sh
+++ b/scripts/ifup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+set -o errexit
+
 brctl addif virbr0 $1
 ifconfig $1 up

--- a/scripts/ifup.sh
+++ b/scripts/ifup.sh
@@ -2,5 +2,10 @@
 
 set -o errexit
 
+if ! [ -x "$(command -v brctl)" ]; then
+  >&2 echo '`brctl` could not be found; please double check that the package is installed.'
+  exit 1
+fi
+
 brctl addif virbr0 $1
 ifconfig $1 up


### PR DESCRIPTION
Currently, the ifup script doesn't fail even if the commands run do. The problem with this is that problems can go unnoticed, since the VM boot immediatley prints a wall of text.

This PR makes the VM startup fail if anything in the script fail, and it also gives (marginally) more helpful information in case the bridge tool is not found.